### PR TITLE
step5 공개여부 퍼블리싱

### DIFF
--- a/src/_components/common/RHFDateRange.tsx
+++ b/src/_components/common/RHFDateRange.tsx
@@ -90,11 +90,7 @@ export default function DateRange({
       </h3>
       {publishDateName && (
         <div className="mb-2">
-          <Input
-            name={publishDateName}
-            label={publishDateLabel}
-            type="date"
-          />
+          <Input name={publishDateName} label={publishDateLabel} type="date" />
           <button
             type="button"
             className="ml-2 px-2 py-1 border rounded text-xs"

--- a/src/_components/steps/Step5.tsx
+++ b/src/_components/steps/Step5.tsx
@@ -1,9 +1,26 @@
 import React from 'react';
+import RadioGroup from '../common/RadioGroup';
+import { VISIBILITY_OPTIONS } from '../../utils/constants';
 
 export default function Step5() {
   return (
     <div className="p-6">
       <h2 className="text-xl font-bold mb-4">Step 5: 공개여부</h2>
+      <div className="space-y-4">
+        <RadioGroup
+          name="isPublic"
+          label="공개 여부"
+          options={VISIBILITY_OPTIONS}
+          required={true}
+        />
+        <div className="mt-4 p-4 bg-gray-50 rounded-lg">
+          <h3 className="font-medium mb-2">안내사항</h3>
+          <ul className="text-sm text-gray-600 space-y-1">
+            <li>• <strong>공개</strong>: 작성한 독후감이 다른 사용자에게 공개됩니다.</li>
+            <li>• <strong>비공개</strong>: 본인만 독후감을 확인할 수 있습니다.</li>
+          </ul>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/_components/steps/step1.tsx
+++ b/src/_components/steps/step1.tsx
@@ -28,8 +28,7 @@ export default function Step1() {
   const { startDisabled, endDisabled } = getDateRangeProps();
 
   // 읽는 중이면 종료일 필드 숨김
-  const hideEndDate =
-    readingStatus === READING_STATUS.READING;
+  const hideEndDate = readingStatus === READING_STATUS.READING;
 
   return (
     <div className="p-4 max-h-screen overflow-y-auto bg-white">

--- a/src/schemas/bookFormSchema.ts
+++ b/src/schemas/bookFormSchema.ts
@@ -176,8 +176,12 @@ const step4Schema = z
     }
   });
 
-// Step 5 스키마 (추후 확장)
-const step5Schema = z.object({});
+// Step 5 스키마 - 공개 여부
+const step5Schema = z.object({
+  isPublic: z.enum(['public', 'private'], {
+    required_error: '공개 여부를 선택해주세요',
+  }),
+});
 
 // 전체 폼 스키마
 export const bookFormSchema = z.object({
@@ -206,7 +210,8 @@ export const bookFormSchema = z.object({
     )
     .optional(),
 
-  // 추후 확장을 위한 필드
+  // Step 5 필드들
+  isPublic: z.enum(['public', 'private']).optional(),
 });
 
 // 스텝별 검증 스키마

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,3 +20,22 @@ export const READING_STATUS_OPTIONS = Object.entries(READING_STATUS_LABELS).map(
   value,
   label,
 }));
+
+// 공개 여부 관련 상수
+export const VISIBILITY_STATUS = {
+  PUBLIC: 'public',
+  PRIVATE: 'private',
+} as const;
+
+export const VISIBILITY_LABELS = {
+  [VISIBILITY_STATUS.PUBLIC]: '공개',
+  [VISIBILITY_STATUS.PRIVATE]: '비공개',
+} as const;
+
+export type VisibilityStatus = typeof VISIBILITY_STATUS[keyof typeof VISIBILITY_STATUS];
+
+// RadioGroup에서 사용할 공개 여부 옵션 배열
+export const VISIBILITY_OPTIONS = Object.entries(VISIBILITY_LABELS).map(([value, label]) => ({
+  value,
+  label,
+}));


### PR DESCRIPTION
  ### 주요 구현 내용

  1. **constants.ts** - 공개 여부 관련 상수 추가
     - `VISIBILITY_STATUS`: 'public', 'private' 값 정의
     - `VISIBILITY_OPTIONS`: RadioGroup에서 사용할 옵션 배열 생성

  2. **bookFormSchema.ts** - Step 5 스키마 구현
     - `isPublic` 필드를 'public' | 'private' enum으로 검증
     - 필수 선택 항목으로 설정

  3. **Step5.tsx** - 공개 여부 선택 UI 구현
     - RadioGroup 컴포넌트를 사용하여 공개/비공개 선택
     - 각 옵션에 대한 설명을 안내사항으로 추가